### PR TITLE
remove redundant initialization of NSData.

### DIFF
--- a/source/tinypng4mac/tpclient/TPClient.swift
+++ b/source/tinypng4mac/tpclient/TPClient.swift
@@ -54,7 +54,7 @@ class TPClient {
 	}
 	
 	func executeTask(task: TPTaskInfo) -> Bool {
-		var imageData: NSData = NSData()
+		var imageData: NSData!
 		do {
 			let fileHandler = try NSFileHandle(forReadingFromURL:task.originFile)
 			imageData = fileHandler.readDataToEndOfFile()


### PR DESCRIPTION
Hi, I found a potential problem that may cause unnecessary memory allocation.
I suggest you to replace `imageData` declaration with a forced unpacking semantics.