### PR TITLE
change file permission to 644

### DIFF
--- a/source/tinypng4mac/tpclient/TPClient.swift
+++ b/source/tinypng4mac/tpclient/TPClient.swift
@@ -143,6 +143,11 @@ class TPClient {
 				} else {
 					self.updateStatus(task, newStatus: .finish)
 					debugPrint("finish: " + task.fileInfo.relativePath + " tasks: " + String(self.runningTasks))
+                    do {
+                        try FileManager.default.setAttributes([FileAttributeKey.posixPermissions: NSNumber(value: 0o644)], ofItemAtPath: task.fileInfo.filePath.path)
+                    } catch {
+                        debugPrint("FileManager set posixPermissions error")
+                    }
 				}
 				
 				self.checkExecution()


### PR DESCRIPTION
Issues:
https://github.com/kyleduo/TinyPNG4Mac/issues/11
Alamofire:
https://github.com/Alamofire/Alamofire/issues/2527

File system permissions set to -rw-r--r--  which can access images directly, no need to chmod manually.