### PR TITLE
Update Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This is a client of [TinyPNG](https://tinypng.com) for Mac, with which you can c
 Homebrew
 
 ```
-brew cask install tinypng4mac
+brew install --cask tinypng4mac
 ```
 
 [Release Page](https://github.com/kyleduo/TinyPNG4Mac/releases)

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -21,7 +21,7 @@
 Homebrew
 
 ```
-brew cask install tinypng4mac
+brew install --cask tinypng4mac
 ```
 
 [Release Page](https://github.com/kyleduo/TinyPNG4Mac/releases) 


### PR DESCRIPTION
Hey 👋 

The installation instructions suggests:

```sh
brew cask install tinypng4mac
```

But if you run that, you'll see:
```
Error: Calling `brew cask install` is disabled! Use brew install [--cask] instead.
```

So we should be running this instead:

```sh
brew install --cask tinypng4mac
```

Which works perfectly:

```
==> Downloading https://github.com/kyleduo/TinyPNG4Mac/releases/download/v1.0.4/
==> Downloading from https://github-releases.githubusercontent.com/62392794/ae3d
######################################################################## 100.0%
==> Installing Cask tinypng4mac
==> Moving App 'TinyPNG4Mac.app' to '/Applications/TinyPNG4Mac.app'
🍺  tinypng4mac was successfully installed!
```