### PR TITLE
Yuman/feature cycle use key

### DIFF
--- a/source/Podfile
+++ b/source/Podfile
@@ -2,11 +2,11 @@
 # platform :ios, '8.0'
 # Uncomment this line if you're using Swift
 platform :osx, '10.12'
-use_frameworks!
+use_frameworks! :linkage => :static
 inhibit_all_warnings!
 
 target 'TinyPNG4Mac' do
 
-pod 'Alamofire', '~> 5.4.4'
+pod 'Alamofire', '~> 5.5'
 
 end

--- a/source/Podfile.lock
+++ b/source/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Alamofire (5.4.4)
+  - Alamofire (5.5.0)
 
 DEPENDENCIES:
-  - Alamofire (~> 5.4.4)
+  - Alamofire (~> 5.5)
 
 SPEC REPOS:
   trunk:
     - Alamofire
 
 SPEC CHECKSUMS:
-  Alamofire: f3b09a368f1582ab751b3fff5460276e0d2cf5c9
+  Alamofire: 1c4fb5369c3fe93d2857c780d8bbe09f06f97e7c
 
-PODFILE CHECKSUM: fca70c836bc7f681bd7150ce8475758a9c56d441
+PODFILE CHECKSUM: 1ccded4c26770105a678e36787f742f427bc57c0
 
 COCOAPODS: 1.11.2

--- a/source/tinypng4mac.xcodeproj/project.pbxproj
+++ b/source/tinypng4mac.xcodeproj/project.pbxproj
@@ -192,7 +192,6 @@
 				277AAF4B1D23F24900788F37 /* Sources */,
 				277AAF4C1D23F24900788F37 /* Frameworks */,
 				277AAF4D1D23F24900788F37 /* Resources */,
-				5B420B6B1C8EFF2B07BE8D63 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -269,24 +268,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5B420B6B1C8EFF2B07BE8D63 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TinyPNG4Mac/Pods-TinyPNG4Mac-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TinyPNG4Mac/Pods-TinyPNG4Mac-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/source/tinypng4mac/Base.lproj/Main.storyboard
+++ b/source/tinypng4mac/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -194,8 +194,8 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fT1-QL-4Nq">
-                                        <rect key="frame" x="125" y="41" width="153" height="22"/>
+                                    <textField wantsLayer="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fT1-QL-4Nq">
+                                        <rect key="frame" x="125" y="42" width="153" height="21"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="99a-9k-u4D">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -215,8 +215,8 @@
                                             <action selector="clickSelectPath:" target="f1c-SR-qaC" id="6zI-cZ-R32"/>
                                         </connections>
                                     </button>
-                                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vPz-Tz-wUm">
-                                        <rect key="frame" x="125" y="68" width="179" height="22"/>
+                                    <textField wantsLayer="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vPz-Tz-wUm">
+                                        <rect key="frame" x="125" y="69" width="179" height="21"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="OCF-de-u9Q">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -224,7 +224,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="zRv-TO-bMw">
-                                        <rect key="frame" x="125" y="16" width="22" height="18"/>
+                                        <rect key="frame" x="125" y="16" width="18" height="18"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="14" id="mm5-iS-Q2I"/>
                                         </constraints>
@@ -282,7 +282,7 @@
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="icon" id="X7r-Gl-0hN"/>
                             </imageView>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.40000000000000002" translatesAutoresizingMaskIntoConstraints="NO" id="IX1-JP-bbZ">
-                                <rect key="frame" x="57" y="197" width="206" height="18"/>
+                                <rect key="frame" x="57" y="198" width="206" height="17"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Drop .JPG/.PNG images here!" id="cXq-XC-8Ss">
                                     <font key="font" metaFont="systemBold" size="14"/>
                                     <color key="textColor" name="highlightColor" catalog="System" colorSpace="catalog"/>
@@ -338,14 +338,13 @@
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="52" viewBased="YES" id="fWd-5L-B1V">
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="248"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="0.0" height="2"/>
                                             <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn width="317" minWidth="40" maxWidth="1000" id="5uH-R6-sDa">
+                                                <tableColumn width="285" minWidth="40" maxWidth="1000" id="5uH-R6-sDa">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -357,7 +356,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <customView identifier="task_cell" id="H7A-f0-c2x" customClass="TaskTableCell" customModule="TinyPNG4Mac" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="1" width="317" height="54"/>
+                                                            <rect key="frame" x="10" y="1" width="297" height="54"/>
                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                             <subviews>
                                                                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="mYs-1G-Pt8">
@@ -369,7 +368,7 @@
                                                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="JHH-DJ-f0H"/>
                                                                 </imageView>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="j8i-Ad-2S2">
-                                                                    <rect key="frame" x="70" y="30" width="46" height="18"/>
+                                                                    <rect key="frame" x="70" y="31" width="46" height="17"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="A.png" id="wj2-uY-zLZ">
                                                                         <font key="font" metaFont="systemBold" size="14"/>
                                                                         <color key="textColor" name="controlLightHighlightColor" catalog="System" colorSpace="catalog"/>
@@ -377,7 +376,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c8G-p9-kpA">
-                                                                    <rect key="frame" x="70" y="10" width="35" height="16"/>
+                                                                    <rect key="frame" x="70" y="12" width="35" height="15"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="LZa-jE-EIr">
                                                                         <font key="font" metaFont="cellTitle"/>
                                                                         <color key="textColor" name="highlightColor" catalog="System" colorSpace="catalog"/>
@@ -385,14 +384,14 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="k4b-cK-7xA" customClass="SpinnerProgressIndicator" customModule="TinyPNG4Mac" customModuleProvider="target">
-                                                                    <rect key="frame" x="285" y="19" width="16" height="16"/>
+                                                                    <rect key="frame" x="265" y="19" width="16" height="16"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="16" id="WPE-uJ-9io"/>
                                                                         <constraint firstAttribute="height" constant="16" id="bND-6C-JLT"/>
                                                                     </constraints>
                                                                 </customView>
                                                                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="LuB-vO-cOE">
-                                                                    <rect key="frame" x="285" y="19" width="16" height="16"/>
+                                                                    <rect key="frame" x="265" y="19" width="16" height="16"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="16" id="sN6-TY-4Ts"/>
                                                                         <constraint firstAttribute="height" constant="16" id="vbV-iA-8wO"/>
@@ -439,7 +438,7 @@
                                 </scroller>
                             </scrollView>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fcw-HM-Ub9">
-                                <rect key="frame" x="107" y="396" width="107" height="17"/>
+                                <rect key="frame" x="107" y="397" width="107" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="TinyPNG for Mac" id="8Ac-Uq-uCZ">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -447,7 +446,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="D8d-TS-a2j">
-                                <rect key="frame" x="14" y="117" width="57" height="17"/>
+                                <rect key="frame" x="14" y="117" width="57" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" truncatesLastVisibleLine="YES" sendsActionOnEndEditing="YES" title="Reduce: " id="400-FH-fhZ">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>

--- a/source/tinypng4mac/zh-Hans.lproj/Main.strings
+++ b/source/tinypng4mac/zh-Hans.lproj/Main.strings
@@ -65,10 +65,10 @@
 /* Class = "NSMenuItem"; title = "Undo"; ObjectID = "sFl-Zo-rnb"; */
 "sFl-Zo-rnb.title" = "重做";
 
-"7df-rK-orR.title" = "重置API Key";
+"7df-rK-orR.title" = "重置API Keys";
 
 /* Class = "NSTextFieldCell"; title = "API Key:"; ObjectID = "tJg-5O-cpK"; */
-"tJg-5O-cpK.title" = "API Key:";
+"tJg-5O-cpK.title" = "API Keys:";
 
 /* Class = "NSMenu"; title = "tinypng"; ObjectID = "uQy-DD-JDr"; */
 "uQy-DD-JDr.title" = "TinyPNG4Mac";


### PR DESCRIPTION

Generally, an apikey only supports uploading 500 pictures a month, so sometimes we will apply for multiple keys.
However, the previous tinypng is not very friendly for multi-key support. When an error exceeding the limit occurs, you need to manually change the key, and then drag the image again.
This commit has two sub-commits:
1 Upgrade Alamofire to version 5.5 and package it with a static library
2 Support multiple keys to be used cyclically, separated by ","
