### PR TITLE
Add Finder service integration and fix Save As folder output creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ TinyPNG for macOS is a 3rd-party client of [TinyPNG](https://tinypng.com). With 
 1. Register an **API key** at [link](https://tinypng.com/developers).
 2. Paste your API key to `Settings` window. (You can edit it when you need to)
 3. Drag images or directories containing images to the window.
+4. Or right-click image files / folders in Finder and choose `Services -> Compress with Tiny Image`.
 
 
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -26,6 +26,7 @@ TinyPNG for macOS 是 [TinyPNG](https://tinypng.com) 的第三方客户端，使
 1. 在 [这里](https://tinypng.com/developers) 注册 **API key**。
 2. 将 API key 粘贴到 `设置` 窗口中。（如果需要，您可以随时修改）
 3. 将图片或包含图片的文件夹拖拽到窗口中。
+4. 或者在 Finder 中右键图片文件 / 文件夹，选择“服务 -> 使用 Tiny Image 压缩”。
 
 
 

--- a/TinyPNG4Mac/TinyPNG4Mac/Info.plist
+++ b/TinyPNG4Mac/TinyPNG4Mac/Info.plist
@@ -29,5 +29,35 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Compress with Tiny Image</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>compressSelection</string>
+			<key>NSPortName</key>
+			<string>Tiny Image</string>
+			<key>NSRequiredContext</key>
+			<dict>
+				<key>NSApplicationIdentifier</key>
+				<string>com.apple.finder</string>
+			</dict>
+			<key>NSSendFileTypes</key>
+			<array>
+				<string>public.image</string>
+				<string>public.folder</string>
+			</array>
+			<key>NSSendTypes</key>
+			<array>
+				<string>public.file-url</string>
+			</array>
+			<key>NSServiceDescription</key>
+			<string>TINY_IMAGE_COMPRESS_SERVICE_DESCRIPTION</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/TinyPNG4Mac/TinyPNG4Mac/TinyPNG4MacApp.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/TinyPNG4MacApp.swift
@@ -36,7 +36,9 @@ struct TinyPNG4MacApp: App {
                     }
                     firstAppear = false
 
-                    appDelgate.updateViewModel(vm: vm)
+                    appDelgate.configure(viewModel: vm) {
+                        openWindow(id: "main")
+                    }
                 }
                 .environmentObject(appContext)
                 .environmentObject(debugVM)
@@ -83,18 +85,41 @@ struct TinyPNG4MacApp: App {
 
 class AppDelegate: NSObject, NSApplicationDelegate {
     private var vm: MainViewModel?
+    private var openMainWindow: (() -> Void)?
 
-    private var openUrls: [URL]?
+    private var pendingOpenUrls: [URL] = []
     private var appDidFinishLaunching = false
 
-    func updateViewModel(vm: MainViewModel) {
+    func configure(viewModel vm: MainViewModel, openMainWindow: @escaping () -> Void) {
         if self.vm == nil {
             self.vm = vm
         }
+        self.openMainWindow = openMainWindow
+
+        tryHandleOpenUrls()
+    }
+
+    @objc(compressSelection:userData:error:)
+    func compressSelection(_ pasteboard: NSPasteboard, userData: String?, error: AutoreleasingUnsafeMutablePointer<NSString?>) {
+        let options: [NSPasteboard.ReadingOptionKey: Any] = [
+            .urlReadingFileURLsOnly: true,
+        ]
+        let urls = (pasteboard.readObjects(forClasses: [NSURL.self], options: options) as? [URL])?
+            .map(\.standardizedFileURL) ?? []
+
+        if urls.isEmpty {
+            error.pointee = "No valid files were provided to Tiny Image." as NSString
+            return
+        }
+
+        enqueueOpenUrls(urls, bringAppToFront: true)
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         FileUtils.initPaths()
+
+        NSApp.servicesProvider = self
+        NSUpdateDynamicServices()
 
         if let window = NSApp.windows.first {
             window.titleVisibility = .hidden
@@ -107,12 +132,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func application(_ application: NSApplication, open urls: [URL]) {
-        openUrls = urls
-        if appDidFinishLaunching {
-            DispatchQueue.main.async {
-                self.tryHandleOpenUrls()
-            }
-        }
+        enqueueOpenUrls(urls, bringAppToFront: true)
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -133,10 +153,38 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func tryHandleOpenUrls() {
-        if let urls = openUrls {
-            openUrls = nil
-            let imageUrls = FileUtils.findImageFiles(urls: urls)
-            vm?.createTasks(imageURLs: imageUrls)
+        guard appDidFinishLaunching, let vm, !pendingOpenUrls.isEmpty else {
+            return
+        }
+
+        let urls = pendingOpenUrls
+        pendingOpenUrls.removeAll()
+
+        let imageUrls = FileUtils.findImageFiles(urls: urls)
+        if !imageUrls.isEmpty {
+            vm.createTasks(imageURLs: imageUrls)
+        }
+    }
+
+    private func enqueueOpenUrls(_ urls: [URL], bringAppToFront: Bool) {
+        guard !urls.isEmpty else {
+            return
+        }
+
+        for url in urls {
+            if !pendingOpenUrls.contains(where: { $0.isSameFilePath(as: url) }) {
+                pendingOpenUrls.append(url)
+            }
+        }
+
+        DispatchQueue.main.async {
+            if bringAppToFront {
+                self.openMainWindow?()
+                NSApp.activate(ignoringOtherApps: true)
+                NSApp.windows.first?.makeKeyAndOrderFront(nil)
+            }
+
+            self.tryHandleOpenUrls()
         }
     }
 }

--- a/TinyPNG4Mac/TinyPNG4Mac/client/TPClient.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/client/TPClient.swift
@@ -203,6 +203,7 @@ class TPClient {
                         downloadedUrl = downloadUrl
                     }
 
+                    try targetUrl.ensureDirectoryExists()
                     try downloadedUrl.moveFileTo(targetUrl)
                     if let filePermission = task.filePermission {
                         targetUrl.setPosixPermissions(filePermission)

--- a/TinyPNG4Mac/TinyPNG4Mac/en.lproj/ServicesMenu.strings
+++ b/TinyPNG4Mac/TinyPNG4Mac/en.lproj/ServicesMenu.strings
@@ -1,0 +1,2 @@
+"Compress with Tiny Image" = "Compress with Tiny Image";
+"TINY_IMAGE_COMPRESS_SERVICE_DESCRIPTION" = "Compress the selected images or folders with Tiny Image.";

--- a/TinyPNG4Mac/TinyPNG4Mac/zh-Hans.lproj/ServicesMenu.strings
+++ b/TinyPNG4Mac/TinyPNG4Mac/zh-Hans.lproj/ServicesMenu.strings
@@ -1,0 +1,2 @@
+"Compress with Tiny Image" = "使用 Tiny Image 压缩";
+"TINY_IMAGE_COMPRESS_SERVICE_DESCRIPTION" = "使用 Tiny Image 压缩所选图片或文件夹。";


### PR DESCRIPTION
## Summary / 概要
- add a Finder Service entry so users can compress selected images and folders directly from Finder  
  添加 Finder 服务入口，支持在 Finder 中直接压缩选中的图片文件和文件夹
- route Finder-triggered files through the existing import pipeline to create compression tasks reliably  
  将 Finder 触发的文件入口接入现有导入链路，确保能够稳定创建压缩任务
- fix Save As mode so nested output directories are created automatically when compressing folders  
  修复“另存为”模式下压缩文件夹时不会自动创建嵌套输出目录的问题
- add localized service menu strings and update the English and Chinese usage docs  
  补充服务菜单本地化文案，并更新中英文使用说明

## Why / 背景
- makes TinyPNG4Mac easier to use in a normal macOS workflow by exposing compression from Finder  
  通过 Finder 提供直接入口，更符合 macOS 日常使用习惯
- fixes a Save As mode bug where folder compression failed unless matching subdirectories were created manually in advance  
  修复一个“另存为”模式的目录压缩问题：此前必须手动预先创建对应子目录，否则压缩会失败

## Testing / 验证
- `xcodebuild -project TinyPNG4Mac/TinyPNG4Mac.xcodeproj -scheme "Tiny Image" -configuration Debug -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project TinyPNG4Mac/TinyPNG4Mac.xcodeproj -scheme "Tiny Image" -configuration Release -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO build`
- manually verified the Finder Service entry appears for image files and folders  
  手动验证 Finder 服务入口会出现在图片文件和文件夹的右键菜单中
- manually verified Save As mode now succeeds for folder compression without pre-creating output subdirectories  
  手动验证“另存为”模式下压缩文件夹时，无需预先创建输出子目录也能成功完成
