### PR TITLE
Split Finder services for in-place and Save As compression

### DIFF
--- a/TinyPNG4Mac/TinyPNG4Mac/Info.plist
+++ b/TinyPNG4Mac/TinyPNG4Mac/Info.plist
@@ -58,6 +58,33 @@
 			<key>NSServiceDescription</key>
 			<string>TINY_IMAGE_COMPRESS_SERVICE_DESCRIPTION</string>
 		</dict>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Compress with Tiny Image and Save As</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>compressSelectionSaveAs</string>
+			<key>NSPortName</key>
+			<string>Tiny Image</string>
+			<key>NSRequiredContext</key>
+			<dict>
+				<key>NSApplicationIdentifier</key>
+				<string>com.apple.finder</string>
+			</dict>
+			<key>NSSendFileTypes</key>
+			<array>
+				<string>public.image</string>
+				<string>public.folder</string>
+			</array>
+			<key>NSSendTypes</key>
+			<array>
+				<string>public.file-url</string>
+			</array>
+			<key>NSServiceDescription</key>
+			<string>TINY_IMAGE_COMPRESS_SAVE_AS_SERVICE_DESCRIPTION</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/TinyPNG4Mac/TinyPNG4Mac/TinyPNG4MacApp.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/TinyPNG4MacApp.swift
@@ -84,10 +84,16 @@ struct TinyPNG4MacApp: App {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate {
+    private struct PendingOpenRequest {
+        let urls: [URL]
+        let saveMode: String?
+        let outputDirectoryUrl: URL?
+    }
+
     private var vm: MainViewModel?
     private var openMainWindow: (() -> Void)?
 
-    private var pendingOpenUrls: [URL] = []
+    private var pendingOpenRequests: [PendingOpenRequest] = []
     private var appDidFinishLaunching = false
 
     func configure(viewModel vm: MainViewModel, openMainWindow: @escaping () -> Void) {
@@ -101,18 +107,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc(compressSelection:userData:error:)
     func compressSelection(_ pasteboard: NSPasteboard, userData: String?, error: AutoreleasingUnsafeMutablePointer<NSString?>) {
-        let options: [NSPasteboard.ReadingOptionKey: Any] = [
-            .urlReadingFileURLsOnly: true,
-        ]
-        let urls = (pasteboard.readObjects(forClasses: [NSURL.self], options: options) as? [URL])?
-            .map(\.standardizedFileURL) ?? []
+        handleServiceRequest(
+            pasteboard,
+            saveMode: AppConfig.saveModeNameOverwrite,
+            requiresOutputDirectorySelection: false,
+            error: error
+        )
+    }
 
-        if urls.isEmpty {
-            error.pointee = "No valid files were provided to Tiny Image." as NSString
-            return
-        }
-
-        enqueueOpenUrls(urls, bringAppToFront: true)
+    @objc(compressSelectionSaveAs:userData:error:)
+    func compressSelectionSaveAs(_ pasteboard: NSPasteboard, userData: String?, error: AutoreleasingUnsafeMutablePointer<NSString?>) {
+        handleServiceRequest(
+            pasteboard,
+            saveMode: AppConfig.saveModeNameSaveAs,
+            requiresOutputDirectorySelection: true,
+            error: error
+        )
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -153,29 +163,49 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func tryHandleOpenUrls() {
-        guard appDidFinishLaunching, let vm, !pendingOpenUrls.isEmpty else {
+        guard appDidFinishLaunching, let vm, !pendingOpenRequests.isEmpty else {
             return
         }
 
-        let urls = pendingOpenUrls
-        pendingOpenUrls.removeAll()
+        let requests = pendingOpenRequests
+        pendingOpenRequests.removeAll()
 
-        let imageUrls = FileUtils.findImageFiles(urls: urls)
-        if !imageUrls.isEmpty {
-            vm.createTasks(imageURLs: imageUrls)
+        for request in requests {
+            let imageUrls = FileUtils.findImageFiles(urls: request.urls)
+            if !imageUrls.isEmpty {
+                vm.createTasks(
+                    imageURLs: imageUrls,
+                    saveMode: request.saveMode,
+                    outputDirectoryUrl: request.outputDirectoryUrl
+                )
+            }
         }
     }
 
-    private func enqueueOpenUrls(_ urls: [URL], bringAppToFront: Bool) {
+    private func enqueueOpenUrls(
+        _ urls: [URL],
+        saveMode: String? = nil,
+        outputDirectoryUrl: URL? = nil,
+        bringAppToFront: Bool
+    ) {
         guard !urls.isEmpty else {
             return
         }
 
+        var uniqueUrls: [URL] = []
         for url in urls {
-            if !pendingOpenUrls.contains(where: { $0.isSameFilePath(as: url) }) {
-                pendingOpenUrls.append(url)
+            if !uniqueUrls.contains(where: { $0.isSameFilePath(as: url) }) {
+                uniqueUrls.append(url.standardizedFileURL)
             }
         }
+
+        pendingOpenRequests.append(
+            PendingOpenRequest(
+                urls: uniqueUrls,
+                saveMode: saveMode,
+                outputDirectoryUrl: outputDirectoryUrl
+            )
+        )
 
         DispatchQueue.main.async {
             if bringAppToFront {
@@ -186,5 +216,63 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             self.tryHandleOpenUrls()
         }
+    }
+
+    private func handleServiceRequest(
+        _ pasteboard: NSPasteboard,
+        saveMode: String,
+        requiresOutputDirectorySelection: Bool,
+        error: AutoreleasingUnsafeMutablePointer<NSString?>
+    ) {
+        let urls = extractFileUrls(from: pasteboard)
+        if urls.isEmpty {
+            error.pointee = "No valid files were provided to Tiny Image." as NSString
+            return
+        }
+
+        let outputDirectoryUrl: URL?
+        if requiresOutputDirectorySelection {
+            guard let selectedDirectory = selectServiceOutputDirectory() else {
+                return
+            }
+            outputDirectoryUrl = selectedDirectory
+        } else {
+            outputDirectoryUrl = nil
+        }
+
+        enqueueOpenUrls(
+            urls,
+            saveMode: saveMode,
+            outputDirectoryUrl: outputDirectoryUrl,
+            bringAppToFront: true
+        )
+    }
+
+    private func extractFileUrls(from pasteboard: NSPasteboard) -> [URL] {
+        let options: [NSPasteboard.ReadingOptionKey: Any] = [
+            .urlReadingFileURLsOnly: true,
+        ]
+        return (pasteboard.readObjects(forClasses: [NSURL.self], options: options) as? [URL])?
+            .map(\.standardizedFileURL) ?? []
+    }
+
+    private func selectServiceOutputDirectory() -> URL? {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.directoryURL = AppContext.shared.appConfig.outputDirectoryUrl ??
+            FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first
+        panel.title = String(localized: "Select output directory")
+        panel.prompt = String(localized: "Select")
+
+        NSApp.activate(ignoringOtherApps: true)
+
+        guard panel.runModal() == .OK else {
+            return nil
+        }
+
+        return panel.url?.standardizedFileURL
     }
 }

--- a/TinyPNG4Mac/TinyPNG4Mac/client/TPClient.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/client/TPClient.swift
@@ -205,6 +205,7 @@ class TPClient {
 
                     try targetUrl.ensureDirectoryExists()
                     try downloadedUrl.moveFileTo(targetUrl)
+                    task.outputUrl = targetUrl
                     if let filePermission = task.filePermission {
                         targetUrl.setPosixPermissions(filePermission)
                     }
@@ -278,7 +279,7 @@ class TPClient {
     private func completeTask(_ task: TaskInfo, fileSizeFromResponse: UInt64, outputType: ImageType?) {
         let finalFileSize: UInt64
         do {
-            finalFileSize = try task.outputUrl!.sizeOfFile()
+            finalFileSize = try task.outputUrl?.sizeOfFile() ?? fileSizeFromResponse
         } catch {
             finalFileSize = fileSizeFromResponse
         }

--- a/TinyPNG4Mac/TinyPNG4Mac/en.lproj/ServicesMenu.strings
+++ b/TinyPNG4Mac/TinyPNG4Mac/en.lproj/ServicesMenu.strings
@@ -1,2 +1,4 @@
 "Compress with Tiny Image" = "Compress with Tiny Image";
 "TINY_IMAGE_COMPRESS_SERVICE_DESCRIPTION" = "Compress the selected images or folders with Tiny Image.";
+"Compress with Tiny Image and Save As" = "Compress with Tiny Image and Save As";
+"TINY_IMAGE_COMPRESS_SAVE_AS_SERVICE_DESCRIPTION" = "Select a destination folder, then compress the selected images or folders with Tiny Image.";

--- a/TinyPNG4Mac/TinyPNG4Mac/model/TaskInfo.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/model/TaskInfo.swift
@@ -11,11 +11,17 @@ import SwiftUI
 class TaskInfo: Identifiable {
     var id: String
     var originUrl: URL
+    /// Selected file or root folder from which the origin image is discovered.
+    var inputUrl: URL
     var filePermission: Int?
     var previewImage: NSImage?
     var backupUrl: URL?
     var downloadUrl: URL?
     var outputUrl: URL?
+    /// Optional task-specific save mode. Falls back to global settings when nil.
+    var saveMode: String?
+    /// Optional task-specific output directory. Falls back to global settings when nil.
+    var outputDirectoryUrl: URL?
     /// types to convert the image to
     /// If nil or empty, do not convert. If provide multiple image types, the smallest one will be used.
     var convertTypes: [ImageType]?
@@ -35,11 +41,15 @@ class TaskInfo: Identifiable {
     init(
         id: String,
         originUrl: URL,
+        inputUrl: URL? = nil,
         status: TaskStatus,
         filePermission: Int? = nil,
         previewImage: NSImage? = nil,
         backupUrl: URL? = nil,
         downloadUrl: URL? = nil,
+        outputUrl: URL? = nil,
+        saveMode: String? = nil,
+        outputDirectoryUrl: URL? = nil,
         originSize: UInt64? = nil,
         finalSize: UInt64? = nil,
         error: TaskError? = nil,
@@ -47,36 +57,47 @@ class TaskInfo: Identifiable {
     ) {
         self.id = id
         self.originUrl = originUrl
+        self.inputUrl = inputUrl ?? originUrl
         self.status = status
         self.filePermission = filePermission
         self.previewImage = previewImage
         self.backupUrl = backupUrl
         self.downloadUrl = downloadUrl
+        self.outputUrl = outputUrl
+        self.saveMode = saveMode
+        self.outputDirectoryUrl = outputDirectoryUrl
         self.originSize = originSize
         self.finalSize = finalSize
         self.error = error
         self.progress = progress
     }
 
-    init(originUrl: URL, backupUrl: URL, downloadUrl: URL, outputUrl: URL, originSize: UInt64, filePermission: Int, previewImage: NSImage, convertTypes: [ImageType]? = nil) {
+    init(originUrl: URL, inputUrl: URL, backupUrl: URL, downloadUrl: URL, outputUrl: URL? = nil, originSize: UInt64, filePermission: Int, previewImage: NSImage, saveMode: String? = nil, outputDirectoryUrl: URL? = nil, convertTypes: [ImageType]? = nil) {
         id = UUID().uuidString
         status = .created
         self.previewImage = previewImage
         self.originUrl = originUrl
+        self.inputUrl = inputUrl
         self.backupUrl = backupUrl
         self.downloadUrl = downloadUrl
         self.outputUrl = outputUrl
         self.originSize = originSize
         self.filePermission = filePermission
+        self.saveMode = saveMode
+        self.outputDirectoryUrl = outputDirectoryUrl
         self.convertTypes = convertTypes
     }
 
     init(originUrl: URL) {
         id = UUID().uuidString
         self.originUrl = originUrl
+        inputUrl = originUrl
         filePermission = nil
         backupUrl = nil
         downloadUrl = nil
+        outputUrl = nil
+        saveMode = nil
+        outputDirectoryUrl = nil
         status = .created
         originSize = 0
         finalSize = 0
@@ -101,6 +122,30 @@ extension TaskInfo: Equatable {
 }
 
 extension TaskInfo {
+    func effectiveSaveMode(config: AppConfig = AppContext.shared.appConfig) -> String {
+        if let saveMode, AppConfig.saveModeKeys.contains(saveMode) {
+            return saveMode
+        }
+        return config.saveMode
+    }
+
+    func effectiveOutputDirectoryUrl(config: AppConfig = AppContext.shared.appConfig) -> URL? {
+        outputDirectoryUrl ?? config.outputDirectoryUrl
+    }
+
+    func resolveOutputUrl(config: AppConfig = AppContext.shared.appConfig) -> URL? {
+        if effectiveSaveMode(config: config) == AppConfig.saveModeNameOverwrite {
+            return originUrl
+        }
+
+        guard let targetDirectory = effectiveOutputDirectoryUrl(config: config) else {
+            return nil
+        }
+
+        let relocatedUrl = FileUtils.getRelocatedRelativePath(of: originUrl, fromDir: inputUrl, toDir: targetDirectory)
+        return relocatedUrl ?? targetDirectory.appendingPathComponent(originUrl.lastPathComponent)
+    }
+
     func updateError(error: TaskError) {
         status = .failed
         self.error = error

--- a/TinyPNG4Mac/TinyPNG4Mac/vms/MainViewModel.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/vms/MainViewModel.swift
@@ -81,8 +81,8 @@ class MainViewModel: ObservableObject, TPClientCallback {
         tasks.count { $0.status == .failed }
     }
 
-    func createTasks(imageURLs: [URL: URL]) {
-        if !validateSettingsBeforeStartTask() {
+    func createTasks(imageURLs: [URL: URL], saveMode: String? = nil, outputDirectoryUrl: URL? = nil) {
+        if !validateSettingsBeforeStartTask(saveMode: saveMode, outputDirectoryUrl: outputDirectoryUrl) {
             return
         }
 
@@ -130,19 +130,6 @@ class MainViewModel: ObservableObject, TPClientCallback {
                     continue
                 }
 
-                let outputUrl: URL
-                if AppContext.shared.appConfig.isOverwriteMode() {
-                    outputUrl = originUrl
-                } else if let outputFolderUrl = AppContext.shared.appConfig.outputDirectoryUrl {
-                    let relocatedUrl = FileUtils.getRelocatedRelativePath(of: originUrl, fromDir: inputUrl, toDir: outputFolderUrl)
-                    outputUrl = relocatedUrl ?? outputFolderUrl.appendingPathComponent(originUrl.lastPathComponent)
-                } else {
-                    let task = TaskInfo(originUrl: originUrl)
-                    task.updateError(error: TaskError.from(error: FileError.noOutput))
-                    appendTask(task: task)
-                    continue
-                }
-                
                 let types: [ImageType]
                 if let convertType = targetConvertType {
                     if convertType == .auto {
@@ -156,14 +143,20 @@ class MainViewModel: ObservableObject, TPClientCallback {
 
                 let task = TaskInfo(
                     originUrl: originUrl,
+                    inputUrl: inputUrl,
                     backupUrl: backupUrl,
                     downloadUrl: downloadUrl,
-                    outputUrl: outputUrl,
                     originSize: fileSize,
                     filePermission: originUrl.posixPermissionsOfFile() ?? 0x644,
                     previewImage: previewImage ?? NSImage(named: "placeholder")!,
+                    saveMode: saveMode,
+                    outputDirectoryUrl: outputDirectoryUrl,
                     convertTypes: types
                 )
+
+                if !prepareTaskForStart(task) {
+                    continue
+                }
 
                 print("Task created: \(task)")
 
@@ -175,6 +168,9 @@ class MainViewModel: ObservableObject, TPClientCallback {
     }
 
     func retry(_ task: TaskInfo) {
+        guard prepareTaskForStart(task) else {
+            return
+        }
         TPClient.shared.addTask(task: task)
     }
 
@@ -236,7 +232,7 @@ class MainViewModel: ObservableObject, TPClientCallback {
 
     /// Validate settings before create tasks.
     /// - Returns true if the settings is valid
-    private func validateSettingsBeforeStartTask() -> Bool {
+    private func validateSettingsBeforeStartTask(saveMode: String? = nil, outputDirectoryUrl: URL? = nil) -> Bool {
         let config = AppContext.shared.appConfig
         if config.apiKey.isEmpty {
             DispatchQueue.main.async {
@@ -245,8 +241,9 @@ class MainViewModel: ObservableObject, TPClientCallback {
             return false
         }
 
-        if config.isSaveAsMode() {
-            if let outputFolderUrl = config.outputDirectoryUrl {
+        let resolvedSaveMode = saveMode ?? config.saveMode
+        if resolvedSaveMode == AppConfig.saveModeNameSaveAs {
+            if let outputFolderUrl = outputDirectoryUrl ?? config.outputDirectoryUrl {
                 if !outputFolderUrl.fileExists() {
                     do {
                         try outputFolderUrl.ensureDirectoryExists()
@@ -273,6 +270,22 @@ class MainViewModel: ObservableObject, TPClientCallback {
             }
         }
 
+        return true
+    }
+
+    private func prepareTaskForStart(_ task: TaskInfo) -> Bool {
+        if !validateSettingsBeforeStartTask(saveMode: task.saveMode, outputDirectoryUrl: task.outputDirectoryUrl) {
+            return false
+        }
+
+        guard let outputUrl = task.resolveOutputUrl() else {
+            DispatchQueue.main.async {
+                self.settingsNotReadyMessage = String(localized: "\"Save As Mode\" is selected. Please config the output directory first.")
+            }
+            return false
+        }
+
+        task.outputUrl = outputUrl
         return true
     }
 

--- a/TinyPNG4Mac/TinyPNG4Mac/zh-Hans.lproj/ServicesMenu.strings
+++ b/TinyPNG4Mac/TinyPNG4Mac/zh-Hans.lproj/ServicesMenu.strings
@@ -1,2 +1,4 @@
 "Compress with Tiny Image" = "使用 Tiny Image 压缩";
-"TINY_IMAGE_COMPRESS_SERVICE_DESCRIPTION" = "使用 Tiny Image 压缩所选图片或文件夹。";
+"TINY_IMAGE_COMPRESS_SERVICE_DESCRIPTION" = "使用 Tiny Image 就地压缩所选图片或文件夹。";
+"Compress with Tiny Image and Save As" = "使用 Tiny Image 另存压缩";
+"TINY_IMAGE_COMPRESS_SAVE_AS_SERVICE_DESCRIPTION" = "先选择目标目录，再使用 Tiny Image 压缩所选图片或文件夹。";


### PR DESCRIPTION
## Summary / 概要
- split the Finder integration into two service entries: one for in-place compression and one for Save As compression  
  将 Finder 集成拆分为两个服务入口：一个用于就地压缩，另一个用于另存压缩
- make `Compress with Tiny Image` always overwrite the selected files in place, regardless of the global Save Mode setting  
  让 `Compress with Tiny Image` 始终就地覆盖所选文件，不受全局“保存模式”设置影响
- add `Compress with Tiny Image and Save As`, which prompts for a destination folder before compressing and saves output there regardless of the global Save Mode setting  
  新增 `Compress with Tiny Image and Save As`，压缩前先选择目标目录，并始终输出到该目录，不受全局“保存模式”设置影响
- store save mode and output directory on each compression task, while falling back to the global settings when no task-specific value is provided  
  将保存模式和输出目录下沉为每个压缩任务的独立属性；当任务未设置时，再回退到全局设置
- keep the final resolved output path on the task so converted files and Finder actions continue to open the correct location  
  在任务上保留最终解析后的输出路径，确保格式转换后的文件和 Finder 操作仍能定位到正确位置

## Why / 背景
- makes the two Finder workflows explicit and predictable without requiring users to switch global settings back and forth  
  让 Finder 中两种常见工作流都更明确、可预期，不需要用户反复切换全局设置
- enables one-off Save As operations from Finder without affecting the default drag-and-drop behavior in the main app  
  支持在 Finder 中执行一次性的“另存压缩”，同时不影响主应用原有的拖拽默认行为
- establishes task-level save configuration so service-triggered jobs can override global output behavior safely  
  建立任务级保存配置能力，使 Finder 服务触发的任务可以安全覆盖全局输出行为

## Testing / 验证
- `xcodebuild -project TinyPNG4Mac/TinyPNG4Mac.xcodeproj -scheme "Tiny Image" -configuration Debug -sdk macosx CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project TinyPNG4Mac/TinyPNG4Mac.xcodeproj -scheme "Tiny Image" -configuration Release -sdk macosx CODE_SIGNING_ALLOWED=NO build`
- manually verified `Compress with Tiny Image` overwrites selected images in place even when the global Save Mode is set to Save As  
  手动验证 `Compress with Tiny Image` 在全局为“另存为模式”时仍会就地覆盖所选图片
- manually verified `Compress with Tiny Image and Save As` prompts for a destination folder and writes output there without using the global output directory  
  手动验证 `Compress with Tiny Image and Save As` 会先弹出目标目录选择框，并输出到所选目录，而不是使用全局输出目录
- manually verified regular drag-and-drop imports still follow the global Save Mode and output directory settings  
  手动验证常规拖拽导入仍继续遵循全局“保存模式”和“输出目录”设置
