### PR TITLE
Enhance Finder service workflows and add HTTP/SOCKS5 proxy settings

### DIFF
--- a/TinyPNG4Mac/TinyPNG4Mac/Info.plist
+++ b/TinyPNG4Mac/TinyPNG4Mac/Info.plist
@@ -58,6 +58,33 @@
 			<key>NSServiceDescription</key>
 			<string>TINY_IMAGE_COMPRESS_SERVICE_DESCRIPTION</string>
 		</dict>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Compress with Tiny Image and Save As</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>compressSelectionSaveAs</string>
+			<key>NSPortName</key>
+			<string>Tiny Image</string>
+			<key>NSRequiredContext</key>
+			<dict>
+				<key>NSApplicationIdentifier</key>
+				<string>com.apple.finder</string>
+			</dict>
+			<key>NSSendFileTypes</key>
+			<array>
+				<string>public.image</string>
+				<string>public.folder</string>
+			</array>
+			<key>NSSendTypes</key>
+			<array>
+				<string>public.file-url</string>
+			</array>
+			<key>NSServiceDescription</key>
+			<string>TINY_IMAGE_COMPRESS_SAVE_AS_SERVICE_DESCRIPTION</string>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/TinyPNG4Mac/TinyPNG4Mac/TinyPNG4MacApp.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/TinyPNG4MacApp.swift
@@ -84,10 +84,16 @@ struct TinyPNG4MacApp: App {
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate {
+    private struct PendingOpenRequest {
+        let urls: [URL]
+        let saveMode: String?
+        let outputDirectoryUrl: URL?
+    }
+
     private var vm: MainViewModel?
     private var openMainWindow: (() -> Void)?
 
-    private var pendingOpenUrls: [URL] = []
+    private var pendingOpenRequests: [PendingOpenRequest] = []
     private var appDidFinishLaunching = false
 
     func configure(viewModel vm: MainViewModel, openMainWindow: @escaping () -> Void) {
@@ -101,18 +107,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc(compressSelection:userData:error:)
     func compressSelection(_ pasteboard: NSPasteboard, userData: String?, error: AutoreleasingUnsafeMutablePointer<NSString?>) {
-        let options: [NSPasteboard.ReadingOptionKey: Any] = [
-            .urlReadingFileURLsOnly: true,
-        ]
-        let urls = (pasteboard.readObjects(forClasses: [NSURL.self], options: options) as? [URL])?
-            .map(\.standardizedFileURL) ?? []
+        handleServiceRequest(
+            pasteboard,
+            saveMode: AppConfig.saveModeNameOverwrite,
+            requiresOutputDirectorySelection: false,
+            error: error
+        )
+    }
 
-        if urls.isEmpty {
-            error.pointee = "No valid files were provided to Tiny Image." as NSString
-            return
-        }
-
-        enqueueOpenUrls(urls, bringAppToFront: true)
+    @objc(compressSelectionSaveAs:userData:error:)
+    func compressSelectionSaveAs(_ pasteboard: NSPasteboard, userData: String?, error: AutoreleasingUnsafeMutablePointer<NSString?>) {
+        handleServiceRequest(
+            pasteboard,
+            saveMode: AppConfig.saveModeNameSaveAs,
+            requiresOutputDirectorySelection: true,
+            error: error
+        )
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -153,29 +163,49 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func tryHandleOpenUrls() {
-        guard appDidFinishLaunching, let vm, !pendingOpenUrls.isEmpty else {
+        guard appDidFinishLaunching, let vm, !pendingOpenRequests.isEmpty else {
             return
         }
 
-        let urls = pendingOpenUrls
-        pendingOpenUrls.removeAll()
+        let requests = pendingOpenRequests
+        pendingOpenRequests.removeAll()
 
-        let imageUrls = FileUtils.findImageFiles(urls: urls)
-        if !imageUrls.isEmpty {
-            vm.createTasks(imageURLs: imageUrls)
+        for request in requests {
+            let imageUrls = FileUtils.findImageFiles(urls: request.urls)
+            if !imageUrls.isEmpty {
+                vm.createTasks(
+                    imageURLs: imageUrls,
+                    saveMode: request.saveMode,
+                    outputDirectoryUrl: request.outputDirectoryUrl
+                )
+            }
         }
     }
 
-    private func enqueueOpenUrls(_ urls: [URL], bringAppToFront: Bool) {
+    private func enqueueOpenUrls(
+        _ urls: [URL],
+        saveMode: String? = nil,
+        outputDirectoryUrl: URL? = nil,
+        bringAppToFront: Bool
+    ) {
         guard !urls.isEmpty else {
             return
         }
 
+        var uniqueUrls: [URL] = []
         for url in urls {
-            if !pendingOpenUrls.contains(where: { $0.isSameFilePath(as: url) }) {
-                pendingOpenUrls.append(url)
+            if !uniqueUrls.contains(where: { $0.isSameFilePath(as: url) }) {
+                uniqueUrls.append(url.standardizedFileURL)
             }
         }
+
+        pendingOpenRequests.append(
+            PendingOpenRequest(
+                urls: uniqueUrls,
+                saveMode: saveMode,
+                outputDirectoryUrl: outputDirectoryUrl
+            )
+        )
 
         DispatchQueue.main.async {
             if bringAppToFront {
@@ -186,5 +216,63 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             self.tryHandleOpenUrls()
         }
+    }
+
+    private func handleServiceRequest(
+        _ pasteboard: NSPasteboard,
+        saveMode: String,
+        requiresOutputDirectorySelection: Bool,
+        error: AutoreleasingUnsafeMutablePointer<NSString?>
+    ) {
+        let urls = extractFileUrls(from: pasteboard)
+        if urls.isEmpty {
+            error.pointee = "No valid files were provided to Tiny Image." as NSString
+            return
+        }
+
+        let outputDirectoryUrl: URL?
+        if requiresOutputDirectorySelection {
+            guard let selectedDirectory = selectServiceOutputDirectory() else {
+                return
+            }
+            outputDirectoryUrl = selectedDirectory
+        } else {
+            outputDirectoryUrl = nil
+        }
+
+        enqueueOpenUrls(
+            urls,
+            saveMode: saveMode,
+            outputDirectoryUrl: outputDirectoryUrl,
+            bringAppToFront: true
+        )
+    }
+
+    private func extractFileUrls(from pasteboard: NSPasteboard) -> [URL] {
+        let options: [NSPasteboard.ReadingOptionKey: Any] = [
+            .urlReadingFileURLsOnly: true,
+        ]
+        return (pasteboard.readObjects(forClasses: [NSURL.self], options: options) as? [URL])?
+            .map(\.standardizedFileURL) ?? []
+    }
+
+    private func selectServiceOutputDirectory() -> URL? {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.directoryURL = AppContext.shared.appConfig.outputDirectoryUrl ??
+            FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first
+        panel.title = String(localized: "Select output directory")
+        panel.prompt = String(localized: "Select")
+
+        NSApp.activate(ignoringOtherApps: true)
+
+        guard panel.runModal() == .OK else {
+            return nil
+        }
+
+        return panel.url?.standardizedFileURL
     }
 }

--- a/TinyPNG4Mac/TinyPNG4Mac/TinyPNG4MacApp.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/TinyPNG4MacApp.swift
@@ -16,11 +16,13 @@ struct TinyPNG4MacApp: App {
     @StateObject var appContext = AppContext.shared
     @StateObject var vm: MainViewModel = MainViewModel()
     @StateObject var debugVM: DebugViewModel = DebugViewModel.shared
-
-    @State var firstAppear: Bool = true
     @State var lastTaskCount = 0
 
     var body: some Scene {
+        let _ = appDelgate.configure(viewModel: vm) {
+            openWindow(id: "main")
+        }
+
         Window("Tiny Image", id: "main") {
             MainContentView(vm: vm)
                 .frame(
@@ -30,16 +32,6 @@ struct TinyPNG4MacApp: App {
                     minHeight: appContext.minSize.height,
                     idealHeight: appContext.minSize.height
                 )
-                .onAppear {
-                    if !firstAppear {
-                        return
-                    }
-                    firstAppear = false
-
-                    appDelgate.configure(viewModel: vm) {
-                        openWindow(id: "main")
-                    }
-                }
                 .environmentObject(appContext)
                 .environmentObject(debugVM)
         }
@@ -90,10 +82,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let outputDirectoryUrl: URL?
     }
 
+    private enum WindowActivation {
+        static let retryDelay: TimeInterval = 0.1
+        static let maxRetryCount = 20
+    }
+
     private var vm: MainViewModel?
     private var openMainWindow: (() -> Void)?
 
     private var pendingOpenRequests: [PendingOpenRequest] = []
+    private var pendingBringAppToFront = false
     private var appDidFinishLaunching = false
 
     func configure(viewModel vm: MainViewModel, openMainWindow: @escaping () -> Void) {
@@ -102,6 +100,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         self.openMainWindow = openMainWindow
 
+        bringMainWindowToFrontIfNeeded()
         tryHandleOpenUrls()
     }
 
@@ -138,11 +137,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         appDidFinishLaunching = true
 
+        bringMainWindowToFrontIfNeeded()
         tryHandleOpenUrls()
     }
 
     func application(_ application: NSApplication, open urls: [URL]) {
         enqueueOpenUrls(urls, bringAppToFront: true)
+    }
+
+    func applicationDidBecomeActive(_ notification: Notification) {
+        bringMainWindowToFrontIfNeeded()
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        requestBringMainWindowToFront()
+        return true
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
@@ -209,9 +218,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         DispatchQueue.main.async {
             if bringAppToFront {
-                self.openMainWindow?()
-                NSApp.activate(ignoringOtherApps: true)
-                NSApp.windows.first?.makeKeyAndOrderFront(nil)
+                self.requestBringMainWindowToFront()
             }
 
             self.tryHandleOpenUrls()
@@ -274,5 +281,54 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         return panel.url?.standardizedFileURL
+    }
+
+    private func requestBringMainWindowToFront() {
+        pendingBringAppToFront = true
+        bringMainWindowToFrontIfNeeded()
+    }
+
+    private func bringMainWindowToFrontIfNeeded(retryCount: Int = WindowActivation.maxRetryCount) {
+        guard pendingBringAppToFront else {
+            return
+        }
+
+        openMainWindow?()
+        NSApp.setActivationPolicy(.regular)
+        NSApp.unhide(nil)
+        NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+        NSApp.activate(ignoringOtherApps: true)
+
+        if let window = preferredWindowForForegrounding() {
+            if window.isMiniaturized {
+                window.deminiaturize(nil)
+            }
+            window.orderFrontRegardless()
+            window.makeKeyAndOrderFront(nil)
+
+            if isWindowFrontmost(window) {
+                pendingBringAppToFront = false
+                return
+            }
+        }
+
+        guard retryCount > 0 else {
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + WindowActivation.retryDelay) { [weak self] in
+            self?.bringMainWindowToFrontIfNeeded(retryCount: retryCount - 1)
+        }
+    }
+
+    private func preferredWindowForForegrounding() -> NSWindow? {
+        NSApp.windows.first(where: { $0.title == "Tiny Image" && !$0.isMiniaturized }) ??
+            NSApp.windows.first(where: { $0.isVisible && !$0.isMiniaturized }) ??
+            NSApp.windows.first(where: { !$0.isMiniaturized }) ??
+            NSApp.windows.first
+    }
+
+    private func isWindowFrontmost(_ window: NSWindow) -> Bool {
+        NSApp.isActive && window.isVisible && (window.isKeyWindow || window == NSApp.keyWindow || window == NSApp.mainWindow)
     }
 }

--- a/TinyPNG4Mac/TinyPNG4Mac/app/AppConfig.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/app/AppConfig.swift
@@ -7,6 +7,82 @@
 
 import Foundation
 
+enum ProxyType: String, CaseIterable {
+    case disabled = "Disabled"
+    case http = "HTTP"
+    case socks5 = "SOCKS5"
+}
+
+struct ProxyConfig {
+    var type: ProxyType = .disabled
+    var server: String = ""
+    var portText: String = ""
+    var username: String = ""
+    var password: String = ""
+
+    var trimmedServer: String {
+        server.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var trimmedPortText: String {
+        portText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var trimmedUsername: String {
+        username.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var port: Int? {
+        Int(trimmedPortText)
+    }
+
+    var isEnabled: Bool {
+        type != .disabled
+    }
+
+    var hasAuthentication: Bool {
+        !trimmedUsername.isEmpty || !password.isEmpty
+    }
+
+    func validationError() -> String? {
+        guard isEnabled else {
+            return nil
+        }
+
+        if trimmedServer.isEmpty {
+            return "Please set the proxy server first."
+        }
+
+        guard let port else {
+            return "Please enter a valid proxy port number."
+        }
+
+        guard (1 ... 65535).contains(port) else {
+            return "Proxy port number must be between 1 and 65535."
+        }
+
+        if trimmedUsername.isEmpty && !password.isEmpty {
+            return "Please set the proxy username before entering a password."
+        }
+
+        return nil
+    }
+
+    func sessionCacheKey() -> String {
+        guard isEnabled else {
+            return type.rawValue
+        }
+
+        return [
+            type.rawValue,
+            trimmedServer.lowercased(),
+            trimmedPortText,
+            trimmedUsername,
+            password,
+        ].joined(separator: "|")
+    }
+}
+
 class AppConfig {
     static let key_apiKey = "apikey"
     static let key_preserveCopyright = "preserveCopyright"
@@ -17,6 +93,11 @@ class AppConfig {
     static let key_outputDirectory = "outputDirectory"
     static let key_usedQuotaCache = "usedQuotaCache"
     static let key_convertingConfig = "convertingConfig"
+    static let key_proxyType = "proxyType"
+    static let key_proxyServer = "proxyServer"
+    static let key_proxyPort = "proxyPort"
+    static let key_proxyUsername = "proxyUsername"
+    static let key_proxyPassword = "proxyPassword"
     
     private static let key_migrated = "migrated"
 
@@ -50,6 +131,7 @@ class AppConfig {
     /// list of target format, empty for don't convert.
     /// Just use the first element so far. Use Array for extension consider.
     private(set) var convertingConfig: [String] = []
+    private(set) var proxyConfig = ProxyConfig()
 
     private var hasMigrated = false
 
@@ -115,6 +197,14 @@ class AppConfig {
             }
             self.convertingConfig = configs
         }
+
+        proxyConfig = ProxyConfig(
+            type: ProxyType(rawValue: ud.string(forKey: AppConfig.key_proxyType) ?? ProxyType.disabled.rawValue) ?? .disabled,
+            server: ud.string(forKey: AppConfig.key_proxyServer) ?? "",
+            portText: ud.string(forKey: AppConfig.key_proxyPort) ?? "",
+            username: ud.string(forKey: AppConfig.key_proxyUsername) ?? "",
+            password: ud.string(forKey: AppConfig.key_proxyPassword) ?? ""
+        )
     }
 
     func currentUsedQuota() -> Int? {
@@ -206,5 +296,9 @@ class AppConfig {
 
     func needPreserveMetadata() -> Bool {
         return preserveCopyright || preserveCreation || preserveLocation
+    }
+
+    func proxyValidationError() -> String? {
+        proxyConfig.validationError()
     }
 }

--- a/TinyPNG4Mac/TinyPNG4Mac/client/TPClient.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/client/TPClient.swift
@@ -205,6 +205,7 @@ class TPClient {
 
                     try targetUrl.ensureDirectoryExists()
                     try downloadedUrl.moveFileTo(targetUrl)
+                    task.outputUrl = targetUrl
                     if let filePermission = task.filePermission {
                         targetUrl.setPosixPermissions(filePermission)
                     }
@@ -278,7 +279,7 @@ class TPClient {
     private func completeTask(_ task: TaskInfo, fileSizeFromResponse: UInt64, outputType: ImageType?) {
         let finalFileSize: UInt64
         do {
-            finalFileSize = try task.outputUrl!.sizeOfFile()
+            finalFileSize = try task.outputUrl?.sizeOfFile() ?? fileSizeFromResponse
         } catch {
             finalFileSize = fileSizeFromResponse
         }

--- a/TinyPNG4Mac/TinyPNG4Mac/client/TPClient.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/client/TPClient.swift
@@ -6,7 +6,40 @@
 //
 
 import Alamofire
+import CFNetwork
 import Foundation
+
+private final class ProxySessionDelegate: SessionDelegate, @unchecked Sendable {
+    private let proxyCredentialProvider: () -> URLCredential?
+
+    init(proxyCredentialProvider: @escaping () -> URLCredential?) {
+        self.proxyCredentialProvider = proxyCredentialProvider
+        super.init()
+    }
+
+    override func urlSession(_ session: URLSession,
+                             task: URLSessionTask,
+                             didReceive challenge: URLAuthenticationChallenge,
+                             completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        let authMethod = challenge.protectionSpace.authenticationMethod
+        let supportedMethods = [
+            NSURLAuthenticationMethodHTTPBasic,
+            NSURLAuthenticationMethodHTTPDigest,
+            NSURLAuthenticationMethodNTLM,
+            NSURLAuthenticationMethodNegotiate,
+        ]
+
+        if challenge.protectionSpace.isProxy(),
+           challenge.previousFailureCount == 0,
+           supportedMethods.contains(authMethod),
+           let credential = proxyCredentialProvider() {
+            completionHandler(.useCredential, credential)
+            return
+        }
+
+        super.urlSession(session, task: task, didReceive: challenge, completionHandler: completionHandler)
+    }
+}
 
 class TPClient {
     static let shared = TPClient()
@@ -27,8 +60,10 @@ class TPClient {
 
     private var taskQueue = TPQueue<TaskInfo>()
     private let lock: NSLock = NSLock()
+    private let sessionLock: NSLock = NSLock()
 
     private var currentRequests: [Request] = []
+    private var sessions: [String: Session] = [:]
 
     func addTask(task: TaskInfo) {
         lock.withLock {
@@ -103,7 +138,7 @@ class TPClient {
                 return
             }
 
-            let uploadRequest = AF.upload(data, to: TPAPI.shrink.rawValue, headers: headers)
+            let uploadRequest = session().upload(data, to: TPAPI.shrink.rawValue, headers: headers)
                 .uploadProgress { progress in
                     if progress.fractionCompleted == 1 {
                         self.updateStatus(.processing, of: task)
@@ -158,9 +193,9 @@ class TPClient {
             req.addValue("application/json", forHTTPHeaderField: "Content-Type")
             req.httpBody = try? JSONSerialization.data(withJSONObject: params, options: [])
 
-            request = AF.download(req)
+            request = session().download(req)
         } else {
-            request = AF.download(output.url, to: destination)
+            request = session().download(output.url, to: destination)
         }
 
         request.downloadProgress { progress in
@@ -274,6 +309,82 @@ class TPClient {
         let authData = auth.data(using: String.Encoding.utf8)?.base64EncodedString(options: NSData.Base64EncodingOptions.lineLength64Characters)
         let authorization = "Basic " + authData!
         return authorization
+    }
+
+    private func session() -> Session {
+        let proxyConfig = AppContext.shared.appConfig.proxyConfig
+        let cacheKey = proxyConfig.sessionCacheKey()
+
+        return sessionLock.withLock {
+            if let cached = sessions[cacheKey] {
+                return cached
+            }
+
+            let session = makeSession(proxyConfig: proxyConfig)
+            sessions[cacheKey] = session
+            return session
+        }
+    }
+
+    private func makeSession(proxyConfig: ProxyConfig) -> Session {
+        let configuration = URLSessionConfiguration.af.default
+
+        if let connectionProxyDictionary = makeConnectionProxyDictionary(proxyConfig: proxyConfig) {
+            configuration.connectionProxyDictionary = connectionProxyDictionary
+        }
+
+        let delegate = ProxySessionDelegate {
+            self.makeProxyCredential(proxyConfig: proxyConfig)
+        }
+        return Session(configuration: configuration, delegate: delegate)
+    }
+
+    private func makeConnectionProxyDictionary(proxyConfig: ProxyConfig) -> [AnyHashable: Any]? {
+        guard proxyConfig.validationError() == nil,
+              proxyConfig.isEnabled,
+              let port = proxyConfig.port else {
+            return nil
+        }
+
+        var dictionary: [AnyHashable: Any] = [:]
+
+        switch proxyConfig.type {
+        case .disabled:
+            return nil
+        case .http:
+            dictionary[kCFNetworkProxiesHTTPEnable as String] = 1
+            dictionary[kCFNetworkProxiesHTTPProxy as String] = proxyConfig.trimmedServer
+            dictionary[kCFNetworkProxiesHTTPPort as String] = port
+            dictionary[kCFNetworkProxiesHTTPSEnable as String] = 1
+            dictionary[kCFNetworkProxiesHTTPSProxy as String] = proxyConfig.trimmedServer
+            dictionary[kCFNetworkProxiesHTTPSPort as String] = port
+        case .socks5:
+            dictionary[kCFNetworkProxiesSOCKSEnable as String] = 1
+            dictionary[kCFNetworkProxiesSOCKSProxy as String] = proxyConfig.trimmedServer
+            dictionary[kCFNetworkProxiesSOCKSPort as String] = port
+            dictionary[kCFStreamPropertySOCKSVersion as String] = kCFStreamSocketSOCKSVersion5
+
+            if !proxyConfig.trimmedUsername.isEmpty {
+                dictionary[kCFStreamPropertySOCKSUser as String] = proxyConfig.trimmedUsername
+            }
+            if !proxyConfig.password.isEmpty {
+                dictionary[kCFStreamPropertySOCKSPassword as String] = proxyConfig.password
+            }
+        }
+
+        return dictionary
+    }
+
+    private func makeProxyCredential(proxyConfig: ProxyConfig) -> URLCredential? {
+        guard proxyConfig.hasAuthentication else {
+            return nil
+        }
+
+        return URLCredential(
+            user: proxyConfig.trimmedUsername,
+            password: proxyConfig.password,
+            persistence: .forSession
+        )
     }
 
     private func completeTask(_ task: TaskInfo, fileSizeFromResponse: UInt64, outputType: ImageType?) {

--- a/TinyPNG4Mac/TinyPNG4Mac/en.lproj/ServicesMenu.strings
+++ b/TinyPNG4Mac/TinyPNG4Mac/en.lproj/ServicesMenu.strings
@@ -1,2 +1,4 @@
 "Compress with Tiny Image" = "Compress with Tiny Image";
 "TINY_IMAGE_COMPRESS_SERVICE_DESCRIPTION" = "Compress the selected images or folders with Tiny Image.";
+"Compress with Tiny Image and Save As" = "Compress with Tiny Image and Save As";
+"TINY_IMAGE_COMPRESS_SAVE_AS_SERVICE_DESCRIPTION" = "Select a destination folder, then compress the selected images or folders with Tiny Image.";

--- a/TinyPNG4Mac/TinyPNG4Mac/model/TaskInfo.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/model/TaskInfo.swift
@@ -11,11 +11,17 @@ import SwiftUI
 class TaskInfo: Identifiable {
     var id: String
     var originUrl: URL
+    /// Selected file or root folder from which the origin image is discovered.
+    var inputUrl: URL
     var filePermission: Int?
     var previewImage: NSImage?
     var backupUrl: URL?
     var downloadUrl: URL?
     var outputUrl: URL?
+    /// Optional task-specific save mode. Falls back to global settings when nil.
+    var saveMode: String?
+    /// Optional task-specific output directory. Falls back to global settings when nil.
+    var outputDirectoryUrl: URL?
     /// types to convert the image to
     /// If nil or empty, do not convert. If provide multiple image types, the smallest one will be used.
     var convertTypes: [ImageType]?
@@ -35,11 +41,15 @@ class TaskInfo: Identifiable {
     init(
         id: String,
         originUrl: URL,
+        inputUrl: URL? = nil,
         status: TaskStatus,
         filePermission: Int? = nil,
         previewImage: NSImage? = nil,
         backupUrl: URL? = nil,
         downloadUrl: URL? = nil,
+        outputUrl: URL? = nil,
+        saveMode: String? = nil,
+        outputDirectoryUrl: URL? = nil,
         originSize: UInt64? = nil,
         finalSize: UInt64? = nil,
         error: TaskError? = nil,
@@ -47,36 +57,47 @@ class TaskInfo: Identifiable {
     ) {
         self.id = id
         self.originUrl = originUrl
+        self.inputUrl = inputUrl ?? originUrl
         self.status = status
         self.filePermission = filePermission
         self.previewImage = previewImage
         self.backupUrl = backupUrl
         self.downloadUrl = downloadUrl
+        self.outputUrl = outputUrl
+        self.saveMode = saveMode
+        self.outputDirectoryUrl = outputDirectoryUrl
         self.originSize = originSize
         self.finalSize = finalSize
         self.error = error
         self.progress = progress
     }
 
-    init(originUrl: URL, backupUrl: URL, downloadUrl: URL, outputUrl: URL, originSize: UInt64, filePermission: Int, previewImage: NSImage, convertTypes: [ImageType]? = nil) {
+    init(originUrl: URL, inputUrl: URL, backupUrl: URL, downloadUrl: URL, outputUrl: URL? = nil, originSize: UInt64, filePermission: Int, previewImage: NSImage, saveMode: String? = nil, outputDirectoryUrl: URL? = nil, convertTypes: [ImageType]? = nil) {
         id = UUID().uuidString
         status = .created
         self.previewImage = previewImage
         self.originUrl = originUrl
+        self.inputUrl = inputUrl
         self.backupUrl = backupUrl
         self.downloadUrl = downloadUrl
         self.outputUrl = outputUrl
         self.originSize = originSize
         self.filePermission = filePermission
+        self.saveMode = saveMode
+        self.outputDirectoryUrl = outputDirectoryUrl
         self.convertTypes = convertTypes
     }
 
     init(originUrl: URL) {
         id = UUID().uuidString
         self.originUrl = originUrl
+        inputUrl = originUrl
         filePermission = nil
         backupUrl = nil
         downloadUrl = nil
+        outputUrl = nil
+        saveMode = nil
+        outputDirectoryUrl = nil
         status = .created
         originSize = 0
         finalSize = 0
@@ -101,6 +122,30 @@ extension TaskInfo: Equatable {
 }
 
 extension TaskInfo {
+    func effectiveSaveMode(config: AppConfig = AppContext.shared.appConfig) -> String {
+        if let saveMode, AppConfig.saveModeKeys.contains(saveMode) {
+            return saveMode
+        }
+        return config.saveMode
+    }
+
+    func effectiveOutputDirectoryUrl(config: AppConfig = AppContext.shared.appConfig) -> URL? {
+        outputDirectoryUrl ?? config.outputDirectoryUrl
+    }
+
+    func resolveOutputUrl(config: AppConfig = AppContext.shared.appConfig) -> URL? {
+        if effectiveSaveMode(config: config) == AppConfig.saveModeNameOverwrite {
+            return originUrl
+        }
+
+        guard let targetDirectory = effectiveOutputDirectoryUrl(config: config) else {
+            return nil
+        }
+
+        let relocatedUrl = FileUtils.getRelocatedRelativePath(of: originUrl, fromDir: inputUrl, toDir: targetDirectory)
+        return relocatedUrl ?? targetDirectory.appendingPathComponent(originUrl.lastPathComponent)
+    }
+
     func updateError(error: TaskError) {
         status = .failed
         self.error = error

--- a/TinyPNG4Mac/TinyPNG4Mac/vms/MainViewModel.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/vms/MainViewModel.swift
@@ -81,8 +81,8 @@ class MainViewModel: ObservableObject, TPClientCallback {
         tasks.count { $0.status == .failed }
     }
 
-    func createTasks(imageURLs: [URL: URL]) {
-        if !validateSettingsBeforeStartTask() {
+    func createTasks(imageURLs: [URL: URL], saveMode: String? = nil, outputDirectoryUrl: URL? = nil) {
+        if !validateSettingsBeforeStartTask(saveMode: saveMode, outputDirectoryUrl: outputDirectoryUrl) {
             return
         }
 
@@ -130,19 +130,6 @@ class MainViewModel: ObservableObject, TPClientCallback {
                     continue
                 }
 
-                let outputUrl: URL
-                if AppContext.shared.appConfig.isOverwriteMode() {
-                    outputUrl = originUrl
-                } else if let outputFolderUrl = AppContext.shared.appConfig.outputDirectoryUrl {
-                    let relocatedUrl = FileUtils.getRelocatedRelativePath(of: originUrl, fromDir: inputUrl, toDir: outputFolderUrl)
-                    outputUrl = relocatedUrl ?? outputFolderUrl.appendingPathComponent(originUrl.lastPathComponent)
-                } else {
-                    let task = TaskInfo(originUrl: originUrl)
-                    task.updateError(error: TaskError.from(error: FileError.noOutput))
-                    appendTask(task: task)
-                    continue
-                }
-                
                 let types: [ImageType]
                 if let convertType = targetConvertType {
                     if convertType == .auto {
@@ -156,14 +143,20 @@ class MainViewModel: ObservableObject, TPClientCallback {
 
                 let task = TaskInfo(
                     originUrl: originUrl,
+                    inputUrl: inputUrl,
                     backupUrl: backupUrl,
                     downloadUrl: downloadUrl,
-                    outputUrl: outputUrl,
                     originSize: fileSize,
                     filePermission: originUrl.posixPermissionsOfFile() ?? 0x644,
                     previewImage: previewImage ?? NSImage(named: "placeholder")!,
+                    saveMode: saveMode,
+                    outputDirectoryUrl: outputDirectoryUrl,
                     convertTypes: types
                 )
+
+                if !prepareTaskForStart(task) {
+                    continue
+                }
 
                 print("Task created: \(task)")
 
@@ -175,6 +168,9 @@ class MainViewModel: ObservableObject, TPClientCallback {
     }
 
     func retry(_ task: TaskInfo) {
+        guard prepareTaskForStart(task) else {
+            return
+        }
         TPClient.shared.addTask(task: task)
     }
 
@@ -236,7 +232,7 @@ class MainViewModel: ObservableObject, TPClientCallback {
 
     /// Validate settings before create tasks.
     /// - Returns true if the settings is valid
-    private func validateSettingsBeforeStartTask() -> Bool {
+    private func validateSettingsBeforeStartTask(saveMode: String? = nil, outputDirectoryUrl: URL? = nil) -> Bool {
         let config = AppContext.shared.appConfig
         if config.apiKey.isEmpty {
             DispatchQueue.main.async {
@@ -245,8 +241,9 @@ class MainViewModel: ObservableObject, TPClientCallback {
             return false
         }
 
-        if config.isSaveAsMode() {
-            if let outputFolderUrl = config.outputDirectoryUrl {
+        let resolvedSaveMode = saveMode ?? config.saveMode
+        if resolvedSaveMode == AppConfig.saveModeNameSaveAs {
+            if let outputFolderUrl = outputDirectoryUrl ?? config.outputDirectoryUrl {
                 if !outputFolderUrl.fileExists() {
                     do {
                         try outputFolderUrl.ensureDirectoryExists()
@@ -273,6 +270,22 @@ class MainViewModel: ObservableObject, TPClientCallback {
             }
         }
 
+        return true
+    }
+
+    private func prepareTaskForStart(_ task: TaskInfo) -> Bool {
+        if !validateSettingsBeforeStartTask(saveMode: task.saveMode, outputDirectoryUrl: task.outputDirectoryUrl) {
+            return false
+        }
+
+        guard let outputUrl = task.resolveOutputUrl() else {
+            DispatchQueue.main.async {
+                self.settingsNotReadyMessage = String(localized: "\"Save As Mode\" is selected. Please config the output directory first.")
+            }
+            return false
+        }
+
+        task.outputUrl = outputUrl
         return true
     }
 

--- a/TinyPNG4Mac/TinyPNG4Mac/vms/MainViewModel.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/vms/MainViewModel.swift
@@ -247,7 +247,6 @@ class MainViewModel: ObservableObject, TPClientCallback {
                 if !outputFolderUrl.fileExists() {
                     do {
                         try outputFolderUrl.ensureDirectoryExists()
-                        return true
                     } catch {
                         DispatchQueue.main.async {
                             self.settingsNotReadyMessage = String(localized: "Failed to create output directory: \(outputFolderUrl.rawPath()), please re-select the output directory.")
@@ -268,6 +267,13 @@ class MainViewModel: ObservableObject, TPClientCallback {
                 }
                 return false
             }
+        }
+
+        if let proxyValidationError = config.proxyValidationError() {
+            DispatchQueue.main.async {
+                self.settingsNotReadyMessage = proxyValidationError
+            }
+            return false
         }
 
         return true

--- a/TinyPNG4Mac/TinyPNG4Mac/windows/SettingsView.swift
+++ b/TinyPNG4Mac/TinyPNG4Mac/windows/SettingsView.swift
@@ -9,6 +9,11 @@ import SwiftUI
 
 struct SettingsView: View {
     @AppStorage(AppConfig.key_apiKey) var apiKey: String = ""
+    @AppStorage(AppConfig.key_proxyType) var proxyType: String = AppContext.shared.appConfig.proxyConfig.type.rawValue
+    @AppStorage(AppConfig.key_proxyServer) var proxyServer: String = AppContext.shared.appConfig.proxyConfig.server
+    @AppStorage(AppConfig.key_proxyPort) var proxyPort: String = AppContext.shared.appConfig.proxyConfig.portText
+    @AppStorage(AppConfig.key_proxyUsername) var proxyUsername: String = AppContext.shared.appConfig.proxyConfig.username
+    @AppStorage(AppConfig.key_proxyPassword) var proxyPassword: String = AppContext.shared.appConfig.proxyConfig.password
 
     @AppStorage(AppConfig.key_preserveCopyright) var preserveCopyright: Bool = false
     @AppStorage(AppConfig.key_preserveCreation) var preserveCreation: Bool = false
@@ -31,6 +36,8 @@ struct SettingsView: View {
 
     @State private var contentSize: CGSize = CGSize.zero
 
+    private let proxyTypeOptions = ProxyType.allCases
+
     var body: some View {
         VStack(alignment: .leading) {
             // Used to make sure content meature correctly
@@ -47,6 +54,61 @@ struct SettingsView: View {
                             .onAppear {
                                 isTextFieldFocused = false
                             }
+                    }
+
+                    SettingsItem(title: "Proxy:", desc: "Supports HTTP and SOCKS5 proxies. Authentication is optional.") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Picker("", selection: $proxyType) {
+                                ForEach(proxyTypeOptions, id: \.self) { type in
+                                    Text(type.rawValue).tag(type.rawValue)
+                                }
+                            }
+                            .padding(.leading, -8)
+                            .frame(maxWidth: 120)
+
+                            if proxyType != ProxyType.disabled.rawValue {
+                                HStack(alignment: .top, spacing: 12) {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text("Server")
+                                            .font(.system(size: 11))
+                                            .foregroundStyle(Color("textSecondary"))
+
+                                        TextField("127.0.0.1", text: $proxyServer)
+                                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                                    }
+
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text("Port")
+                                            .font(.system(size: 11))
+                                            .foregroundStyle(Color("textSecondary"))
+
+                                        TextField("7890", text: $proxyPort)
+                                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                                            .frame(width: 96)
+                                    }
+                                }
+
+                                HStack(alignment: .top, spacing: 12) {
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text("Username")
+                                            .font(.system(size: 11))
+                                            .foregroundStyle(Color("textSecondary"))
+
+                                        TextField("Optional", text: $proxyUsername)
+                                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                                    }
+
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text("Password")
+                                            .font(.system(size: 11))
+                                            .foregroundStyle(Color("textSecondary"))
+
+                                        SecureField("Optional", text: $proxyPassword)
+                                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                                    }
+                                }
+                            }
+                        }
                     }
 
                     SettingsItem(title: "Preserve:", desc: nil) {

--- a/TinyPNG4Mac/TinyPNG4Mac/zh-Hans.lproj/ServicesMenu.strings
+++ b/TinyPNG4Mac/TinyPNG4Mac/zh-Hans.lproj/ServicesMenu.strings
@@ -1,2 +1,4 @@
 "Compress with Tiny Image" = "使用 Tiny Image 压缩";
-"TINY_IMAGE_COMPRESS_SERVICE_DESCRIPTION" = "使用 Tiny Image 压缩所选图片或文件夹。";
+"TINY_IMAGE_COMPRESS_SERVICE_DESCRIPTION" = "使用 Tiny Image 就地压缩所选图片或文件夹。";
+"Compress with Tiny Image and Save As" = "使用 Tiny Image 另存压缩";
+"TINY_IMAGE_COMPRESS_SAVE_AS_SERVICE_DESCRIPTION" = "先选择目标目录，再使用 Tiny Image 压缩所选图片或文件夹。";


### PR DESCRIPTION
## Summary / 概要
- split the Finder integration into two service entries: one for in-place compression and one for Save As compression  
  将 Finder 集成拆分为两个服务入口：一个用于就地压缩，另一个用于另存压缩

- make `Compress with Tiny Image` always overwrite the selected files in place, regardless of the global Save Mode setting  
  让 `Compress with Tiny Image` 始终就地覆盖所选文件，不受全局“保存模式”设置影响

- add `Compress with Tiny Image and Save As`, which prompts for a destination folder before compressing and saves output there regardless of the global Save Mode setting  
  新增 `Compress with Tiny Image and Save As`，压缩前先选择目标目录，并始终输出到该目录，不受全局“保存模式”设置影响

- store save mode and output directory on each compression task, while falling back to the global settings when no task-specific value is provided  
  将保存模式和输出目录下沉为每个压缩任务的独立属性；当任务未设置时，再回退到全局设置

- keep the final resolved output path on the task so converted files and Finder actions continue to open the correct location  
  在任务上保留最终解析后的输出路径，确保格式转换后的文件和 Finder 操作仍能定位到正确位置

- reliably foreground the app and main window when Finder service actions are triggered, including activation retries and reopen handling  
  在通过 Finder 服务触发操作时，可靠地将应用及主窗口前置，包括激活重试和重新打开窗口处理

- add HTTP and SOCKS5 proxy settings in the app, including server, port, and optional authentication fields  
  在应用设置中新增 HTTP 和 SOCKS5 代理配置，支持服务器、端口和可选认证信息

- persist proxy configuration, validate proxy input, and route TinyPNG requests through the configured proxy  
  持久化代理配置，校验代理输入，并让 TinyPNG 请求通过配置的代理发送

## Why / 背景
- makes the two Finder workflows explicit and predictable without requiring users to switch global settings back and forth  
  让 Finder 中两种常见工作流都更明确、可预期，不需要用户反复切换全局设置

- improves the reliability of Finder service invocations by making sure the app is actually brought to the foreground when user interaction is needed  
  提升 Finder 服务调用的可靠性，确保在需要用户交互时应用能够真正前置显示

- enables one-off Save As operations from Finder without affecting the default drag-and-drop behavior in the main app  
  支持在 Finder 中执行一次性的“另存压缩”，同时不影响主应用原有的拖拽默认行为

- allows users in restricted or proxied network environments to use TinyPNG without relying on system-wide proxy configuration  
  让处于受限网络或代理网络环境下的用户无需修改系统级代理，也能使用 TinyPNG

- establishes task-level save configuration so service-triggered jobs can override global output behavior safely  
  建立任务级保存配置能力，使 Finder 服务触发的任务可以安全覆盖全局输出行为

## Testing / 验证
- `xcodebuild -project TinyPNG4Mac/TinyPNG4Mac.xcodeproj -scheme "Tiny Image" -configuration Debug -sdk macosx CODE_SIGNING_ALLOWED=NO build`

- manually verified `Compress with Tiny Image` overwrites selected images in place even when the global Save Mode is set to Save As  
  手动验证 `Compress with Tiny Image` 在全局为“另存为模式”时仍会就地覆盖所选图片

- manually verified `Compress with Tiny Image and Save As` prompts for a destination folder and writes output there without using the global output directory  
  手动验证 `Compress with Tiny Image and Save As` 会先弹出目标目录选择框，并输出到所选目录，而不是使用全局输出目录

- manually verified Finder service invocations reliably bring the app window to the foreground before presenting interactive UI  
  手动验证 Finder 服务触发时会可靠地将应用窗口前置，再展示需要交互的 UI

- manually verified regular drag-and-drop imports still follow the global Save Mode and output directory settings  
  手动验证常规拖拽导入仍继续遵循全局“保存模式”和“输出目录”设置